### PR TITLE
Fix typo; provide slot index information in the API

### DIFF
--- a/advtrains_livery_database/init.lua
+++ b/advtrains_livery_database/init.lua
@@ -344,7 +344,8 @@ function advtrains_livery_database.get_wagon_livery_template(wagon_type, livery_
 	for id, overlay in ipairs(livery_templates[wagon_type][livery_template_name].overlays) do
 		wagon_livery_template.overlays[id] = {
 			name = overlay.name,
-			texture = overlay.textute,
+			slot_idx = overlay.slot_idx,
+			texture = overlay.texture,
 			alpha = overlay.alpha,
 		}
 	end


### PR DESCRIPTION
This change is needed for [wagon previews in the `advtrains_doc_integration` mod](https://notabug.org/y5nw/advtrains_doc_integration/commit/977121779680eebd0c235e2e77bdb4368e519b00#diff-82b191044e20d996fcdeb881f21cbc28fcedac3R209) to work properly.

On a less related note, perhaps [`table.copy`](http://minetest.gitlab.io/minetest/helper-functions/) should be used instead.